### PR TITLE
Fix Typo: Replace "PlaceReducer" with "placeReducer" 

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useReducer, useRef } from 'react';
-import { PlaceReducer, placeInitialState } from 'src/reducers/PlaceReducer';
+import { placeReducer, placeInitialState } from 'src/reducers/PlaceReducer';
 import './App.css';
 import { AppHeader } from './components/Header/Header';
 import { PlaceFlow } from './components/view/PlaceFlow';
@@ -11,7 +11,7 @@ import {
 export function App() {
   const searchInputRef = useRef<HTMLInputElement | null>(null);
   const [placeState, placeDispatchAction] = useReducer(
-    PlaceReducer,
+    placeReducer,
     placeInitialState
   );
 

--- a/src/context/Places/PlaceContextProvider.tsx
+++ b/src/context/Places/PlaceContextProvider.tsx
@@ -1,5 +1,5 @@
 import { useReducer } from 'react';
-import { PlaceReducer, placeInitialState } from 'src/reducers/PlaceReducer';
+import { placeReducer, placeInitialState } from 'src/reducers/PlaceReducer';
 import { PlaceContext, PlaceDispatchContext } from './PlacesContext';
 
 type IPlaceProviderProps = {
@@ -7,7 +7,7 @@ type IPlaceProviderProps = {
 };
 
 export function PlaceProvider({ children }: IPlaceProviderProps) {
-  const [state, dispatch] = useReducer(PlaceReducer, placeInitialState);
+  const [state, dispatch] = useReducer(placeReducer, placeInitialState);
 
   return (
     <PlaceContext value={state}>

--- a/src/reducers/PlaceReducer.ts
+++ b/src/reducers/PlaceReducer.ts
@@ -37,7 +37,7 @@ export const placeInitialState: IPlaceReducerState = {
 };
 
 //reducer function
-export const PlaceReducer = (
+export const placeReducer = (
   state: IPlaceReducerState,
   action: IPlaceReducerAction
 ): IPlaceReducerState => {

--- a/src/tests/unit/app.test.tsx
+++ b/src/tests/unit/app.test.tsx
@@ -1,4 +1,4 @@
-import { PlaceReducer } from 'src/reducers/PlaceReducer';
+import { placeReducer } from 'src/reducers/PlaceReducer';
 import type { IPlaceReducerState } from 'src/shared/types';
 import { describe, expect, test } from 'vitest';
 
@@ -14,7 +14,7 @@ describe('Test all actions of placeReducer ', () => {
   };
 
   test('should update the appMode to form_adding_details', () => {
-    const result = PlaceReducer(initialState, {
+    const result = placeReducer(initialState, {
       type: 'Set_Update_App_Mode',
       payload: 'form_adding_details',
     });
@@ -22,7 +22,7 @@ describe('Test all actions of placeReducer ', () => {
   });
 
   test("the test shouldn't pass if the value expected is not form_adding_details", () => {
-    const result = PlaceReducer(initialState, {
+    const result = placeReducer(initialState, {
       type: 'Set_Update_App_Mode',
       payload: 'form_adding_details',
     });

--- a/src/tests/unit/placeReducer.test.tsx
+++ b/src/tests/unit/placeReducer.test.tsx
@@ -1,4 +1,4 @@
-import { PlaceReducer } from 'src/reducers/PlaceReducer';
+import { placeReducer } from 'src/reducers/PlaceReducer';
 import type { IPlaceReducerState } from 'src/shared/types';
 import { describe, expect, test } from 'vitest';
 
@@ -14,7 +14,7 @@ describe('Test all actions of placeReducer ', () => {
   };
 
   test('should update the appMode to form_adding_details', () => {
-    const result = PlaceReducer(initialState, {
+    const result = placeReducer(initialState, {
       type: 'Set_Update_App_Mode',
       payload: 'form_adding_details',
     });
@@ -22,7 +22,7 @@ describe('Test all actions of placeReducer ', () => {
   });
 
   test("the test shouldn't pass if the value expected is not form_adding_details", () => {
-    const result = PlaceReducer(initialState, {
+    const result = placeReducer(initialState, {
       type: 'Set_Update_App_Mode',
       payload: 'form_adding_details',
     });


### PR DESCRIPTION
## What does this PR do?
Replaced `PlaceReducer` component's name with `placeReducer` to ensured consistent naming conventions throughout the codebase.

## Key Changes
- Replaced `PlaceReducer` component's name with `placeReducer`
- Ensured consistent naming conventions throughout the codebase.

Outside the codebase
(none for this PR)

## How to Test
- Review the updated code to ensure the changes are correct and consistent.
- Verify that the typo is fixed and does not cause any errors or issues.

